### PR TITLE
build and push image to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 orbs:
   cypress: cypress-io/cypress@1.19.1
+  aws-ecr: circleci/aws-ecr@6.8.1
 workflows:
-    build-and-test:
+    test-and-deploy:
       jobs:
         - cypress/run:
             start: npm start
@@ -13,3 +14,8 @@ workflows:
               - store_artifacts:
                   path: test-results
                   destination: test-results
+        - aws-ecr/build-and-push-image:
+            requires:
+              - cypress/run
+            context: aws-context
+            repo: vspan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:alpine3.11
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+COPY ./public ./
+COPY server.js ./
+
+ENV NODE_ENV production
+
+RUN npm install
+
+EXPOSE 8080
+
+USER "node"
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This patch adds logic to support building and pushing an image
of the web app to ECR. Specifically:
- A Dockerfile is added that builds the web app into a production
image.
- The circleci/aws-ecr orb is used in the circleci config to build
and push the image to AWS ECR.